### PR TITLE
Fixing a crash due to None type passed to map

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -1123,6 +1123,10 @@ class CBinDiff:
           decoded_size = 1
 
         curr_bytes = GetManyBytes(x, decoded_size)
+        if curr_bytes is None or len(curr_bytes) != decoded_size:
+            print 'Failed to read %d bytes at [%08x]' % (decoded_size, x)
+            continue
+        
         bytes_hash.append(curr_bytes)
         bytes_sum += sum(map(ord, curr_bytes))
 


### PR DESCRIPTION
Diaphora will crash if GetManyBytes returns a None type (such as on externs in arm64) which is then passed to the map function. Included patch fixes the hard crash and seems to have no adverse affects.

Error: argument 2 to map() must support iteration
Traceback (most recent call last):
  File "./diaphora.py", line 3690, in _diff_or_export
    bd.export()
  File "./diaphora.py", line 1502, in export
    self.do_export()
  File "./diaphora.py", line 1478, in do_export
    props = self.read_function(func)
  File "./diaphora.py", line 1127, in read_function
    bytes_sum += sum(map(ord, curr_bytes))
TypeError: argument 2 to map() must support iteration
