### PR TITLE
Exporting idb's with less then 100 functions fails

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -1480,7 +1480,7 @@ class CBinDiff:
     t = time.time()
     for func in func_list:
       i += 1
-      if i % (total_funcs/100) == 0 or i == 1:
+      if (total_funcs > 100) and i % (total_funcs/100) == 0 or i == 1:
         line = "Exported %d function(s) out of %d total.\nElapsed %d:%02d:%02d second(s), remaining time ~%d:%02d:%02d"
         elapsed = time.time() - t
         remaining = (elapsed / i) * (total_funcs - i)


### PR DESCRIPTION
Just a small bug causing the script to fail. 
At https://github.com/joxeankoret/diaphora/blob/master/diaphora.py#L1483 where 
it tries to report progress for large IDBs , the calucaltion in `if` statement will
fail with divide by zero if `total_funcs` is less then 100. 

Cheers,
ea