### PR TITLE
Automatically diff two exported databases (without requiring IDA!)

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -1091,7 +1091,7 @@ class CBinDiff:
       sql = "insert into config values (?, ?, ?, ?)"
       cur.execute(sql, (self.db_name, self.last_diff_db, VERSION_VALUE, time.asctime()))
 
-      sql = "create table results (type, line, address, name, address2, name2, ratio, description, bb1, bb2)"
+      sql = "create table results (type, line, address, name, address2, name2, ratio, bb1, bb2, description)"
       cur.execute(sql)
 
       sql = "create table unmatched (type, line, address, name)"
@@ -2381,7 +2381,7 @@ class CBinDiff:
     if len(rows) > 0:
       for row in rows:
         name = row[1]
-        ea = LocByName(name)
+        ea = row[0]
         ea2 = row[0]
         nodes = int(row[2])
 


### PR DESCRIPTION
Hi,


This pull request adds functionality to allow for automatic diffing of two exported databases. The following environment variables should be set to make use of the functionality:

- DIAPHORA_AUTO_DIFF
- DIAPHORA_DB1
- DIAPHORA_DB2
- DIAPHORA_DIFF_OUT

Example usage:

`$ DIAPHORA_AUTO_DIFF=1 DIAPHORA_DB1=first.sqlite DIAPHORA_DB2=second.sqlite DIAPHORA_DIFF_OUT=diff.sqlite python diaphora.py`

The cool thing is that this approach does allow for batch diffing available databases, without requiring IDA to be available on the machine.


Greetings,
Jarno