### PR TITLE
Added option to exclude library and thunk functions.

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -194,6 +194,7 @@ class CBinDiff:
     self.experimental = False
     self.slow_heuristics = False
     self.use_decompiler_always = True
+    self.exclude_library_thunk = True
 
     # Create the choosers
     self.chooser = chooser


### PR DESCRIPTION
Added option to exclude functions that are flagged as `FUNC_LIB` or `FUNC_THUNK`. The current option to ignore library functions is a little bit too harsh (also ignoring sub_, j_ and unknown functions) and the option to ignore thunk functions is helpful as well.

I needed this for my own project, but thought it might be useful for other use cases as well.

Greetings,
Jarno