### PR TITLE
Moving Pseudo-code Fuzzy AST Hash to Slow Heuristics

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -1698,18 +1698,19 @@ class CBinDiff:
       log_refresh("Finding with heuristic 'Similar pseudo-code'")
       self.add_matches_from_query_ratio_max(sql, choose, self.unreliable_chooser, 0.6)
 
-    sql = """select distinct f.address ea, f.name name1, df.address ea2, df.name name2, 'Pseudo-code fuzzy AST hash' description,
-                    f.pseudocode pseudo1, df.pseudocode pseudo2,
-                    f.assembly asm1, df.assembly asm2,
-                    f.pseudocode_primes pseudo_primes1, df.pseudocode_primes pseudo_primes2,
-                    f.nodes bb1, df.nodes bb2
-               from functions f,
-                    diff.functions df
-              where df.pseudocode_primes = f.pseudocode_primes
-                and f.pseudocode_lines > 3
-                and length(f.pseudocode_primes) >= 35""" + postfix
-    log_refresh("Finding with heuristic 'Pseudo-code fuzzy AST hash'")
-    self.add_matches_from_query_ratio(sql, self.best_chooser, choose)
+    if self.slow_heuristics:
+      sql = """select distinct f.address ea, f.name name1, df.address ea2, df.name name2, 'Pseudo-code fuzzy AST hash' description,
+                      f.pseudocode pseudo1, df.pseudocode pseudo2,
+                      f.assembly asm1, df.assembly asm2,
+                      f.pseudocode_primes pseudo_primes1, df.pseudocode_primes pseudo_primes2,
+                      f.nodes bb1, df.nodes bb2
+                 from functions f,
+                      diff.functions df
+                where df.pseudocode_primes = f.pseudocode_primes
+                  and f.pseudocode_lines > 3
+                  and length(f.pseudocode_primes) >= 35""" + postfix
+      log_refresh("Finding with heuristic 'Pseudo-code fuzzy AST hash'")
+      self.add_matches_from_query_ratio(sql, self.best_chooser, choose)
 
     if self.slow_heuristics:
       sql = """  select distinct f.address ea, f.name name1, df.address ea2, df.name name2, 'Partial pseudo-code fuzzy hash' description,


### PR DESCRIPTION
For a large binary (133MB), this heuristic was taking over an hour (I stopped it early, it never completed)

Unless I am mistaken, and this was due to some other underlying problem, then this heuristic should be treated as a slow heuristic.

Edit: Made an issue here https://github.com/joxeankoret/diaphora/issues/76 in case this requires further discussion, or if my provided fix is invalid in other ways