### PR TITLE
FixBug: can't export arm/arm64 decompiling result in batch mode

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -1008,7 +1008,10 @@ class CIDABinDiff(diaphora.CBinDiff):
       traceback.print_exc()
 
   def decompile_and_get(self, ea):
-    if not init_hexrays_plugin() and not (load_plugin("hexrays") and init_hexrays_plugin()):
+    decompiler_plugin = os.getenv("DIAPHORA_DECOMPILER_PLUGIN")
+    if decompiler_plugin is None:
+      decompiler_plugin = "hexrays"
+    if not init_hexrays_plugin() and not (load_plugin(decompiler_plugin) and init_hexrays_plugin()):
       return False
 
     f = get_func(ea)


### PR DESCRIPTION
FixBug: can't export arm/arm64 decompiling result in batch mode
Reason: the decompiler plugin's name is hard coded(hexrays).
Usage: 
arm: `DIAPHORA_DECOMPILER_PLUGIN="hexarm" DIAPHORA_AUTO=1 DIAPHORA_EXPORT_FILE=f.sqlite DIAPHORA_USE_DECOMPILER=1 idaq -A -B -c -Sdiaphora.py binary`
arm64: `DIAPHORA_DECOMPILER_PLUGIN="hexarm64" DIAPHORA_AUTO=1 DIAPHORA_EXPORT_FILE=f.sqlite DIAPHORA_USE_DECOMPILER=1 idaq -A -B -c -Sdiaphora.py binary`
Note: The method used to fix this bug is direct, maybe it doestn't meet your design.