### PR TITLE
ida: Fix import_selected not working properly

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -1148,7 +1148,7 @@ class CIDABinDiff(diaphora.CBinDiff):
 
     new_items = []
     for index in selected:
-      item = items[index-1]
+      item = items[index]
       name1 = item[2]
       if not only_auto or name1.startswith("sub_"):
         new_items.append(item)


### PR DESCRIPTION
The selected array already contains indexes (0..n-1) so there was
no need to subtract 1.

This fixes 'Import selected' which just wouldn't be able to import
anything in some cases (still not sure how sometimes it works).