### PR TITLE
Change the logic for handling row deletion in CIDAChooser

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -210,10 +210,8 @@ class CIDAChooser(diaphora.CChooser, Choose2):
     return len(self.items)
 
   def OnDeleteLine(self, n):
-    try:
+    if n >= 0:
       del self.items[n]
-    except:
-      pass
     return True
 
   def OnRefresh(self, n):


### PR DESCRIPTION
According to my testing (IDA 6.8) (unfortunately I can't find documentation for old API), the deletion function is called with parameter `-1` before all deletion commands, and `-2` after that. So this should fix the issue (instead of accidentally delete 2 unrelated rows)

I know IDA 6.8 is unsupported, but it would be better for the program to support more versions anyway.

Does this work properly in newer versions?
