### PR TITLE
Don't overwrite true_name with demangled name

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -1392,7 +1392,6 @@ or selecting Edit -> Plugins -> Diaphora - Show results""")
 
     if demangled_name is not None:
       name = demangled_name
-      true_name = name
 
     if self.hooks is not None:
       ret = self.hooks.before_export_function(f, name)


### PR DESCRIPTION
Otherwise demangled names will be used verbatim yielding weird results