### PR TITLE
Warn users if they are using Python2 instead of Python3 in Diaphora master version

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import sys
 import os
 import re
 import sys
@@ -2117,6 +2118,14 @@ class CBinDiff:
     return True
 
 if __name__ == "__main__":
+
+
+  version_info = sys.version_info
+  if version_info[0] == 2:
+      log("You are using Python2 instead of Python3, Diaphora master" 
+              "works Python3 but there are other branches that contain" 
+              "backward compatability")
+
   do_diff = True
   if os.getenv("DIAPHORA_AUTO_DIFF") is not None:
     db1 = os.getenv("DIAPHORA_DB1")


### PR DESCRIPTION
I wanted to diff using Diaphora in my IDA 7.5 version, however as I was using Python2 
I got a few exceptions, (especially when dealing with bytes vs ints), as I thought it's a bug I went 
over the sources and noticed the README.md states that diaphora it is working on Pyhton 3 
however there is no check that identifies that, thus making Diaphora break or run recklessly on older Python versions.

I added a simple warning to hint users that they are doing something weird.

hth 💙

Cheers,
  Guy 