### PR TITLE
Fix re-loaded and re-saved diffs omitting the 2nd DB path

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -939,6 +939,7 @@ class CIDABinDiff(diaphora.CBinDiff):
 
     self.__init__(main_db)
     self.attach_database(diff_db)
+    self.last_diff_db = diff_db
 
     if create_choosers:
       self.create_choosers()
@@ -2342,13 +2343,13 @@ or selecting Edit -> Plugins -> Diaphora - Show results""")
 
       main_db = row["main_db"]
       diff_db = row["diff_db"]
-      if not os.path.exists(main_db):
+      if main_db is None or not os.path.exists(main_db):
         log("Primary database %s not found." % main_db)
         main_db = ask_file(0, main_db, "Select the primary database path")
         if main_db is None:
           return False
 
-      if not os.path.exists(diff_db):
+      if diff_db is None or not os.path.exists(diff_db):
         diff_db = ask_file(0, main_db, "Select the secondary database path")
         if diff_db is None:
           return False


### PR DESCRIPTION
This PR fixes a bug where the following sequence of actions would produce a `.diaphora` file that fails to load in the plugin:

1. Create a diff.
2. Save it to a `.diaphora` file (from `Plugins -> Diaphora - Save`).
3. Relaunch IDA and re-load that file.
4. Re-save it again (from the RMB context menu).
5. Attempt to re-load the re-saved database again. Notice the DB cannot be loaded due to an exception thrown inside `os.path.exists(diff_db)`.

With this PR, the following two fixes correct the functionality:
* Re-loaded diffs can now re-save the path properly.
* "Broken" diff files can now be loaded, because a null `diff_db` is now gracefully handled, allowing for the fallback (where the user points the plugin at the database again) to work as intended.