### PR TITLE
Simple fix for re.error in pygments/util

### DIFF
--- a/pygments/util.py
+++ b/pygments/util.py
@@ -24,7 +24,7 @@ doctype_lookup_re = re.compile(r'''(?smx)
      )
      [^>]*>
 ''')
-tag_re = re.compile(r'<(.+?)(\s.*?)?>.*?</.+?>(?uism)')
+tag_re = re.compile(r'(?uism)<(.+?)(\s.*?)?>.*?</.+?>')
 xml_decl_re = re.compile(r'\s*<\?xml[^>]*\?>', re.I)
 
 


### PR DESCRIPTION
Moved the global flags to the beginning of the regex, to be compatible with Python 3.7 and later. 
Tested with Python 3.7, 3.8, 3.9 and 3.11 on IDA 8.1 👍 
Fixes issue #243 

Note: A more comprehensive PR (#240) is also available that will upgrade pygments to 2.13. 