### PR TITLE
allow efficient diffing from the command line (integrated with idahunt)

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -2071,7 +2071,6 @@ class CBinDiff:
       cur.close()
     return True
 
-g_debug = False
 if __name__ == "__main__":
   version_info = sys.version_info
   if version_info[0] == 2:
@@ -2079,11 +2078,10 @@ if __name__ == "__main__":
     log("TIP: There are other branches that contain backward compatibility.")
 
   do_diff = True
-  if g_debug:
-    log("DIAPHORA_AUTO_DIFF=%s" % os.getenv("DIAPHORA_AUTO_DIFF"))
-    log("DIAPHORA_DB1=%s" % os.getenv("DIAPHORA_DB1"))
-    log("DIAPHORA_DB2=%s" % os.getenv("DIAPHORA_DB2"))
-    log("DIAPHORA_DIFF_OUT=%s" % os.getenv("DIAPHORA_DIFF_OUT"))
+  debug_refresh("DIAPHORA_AUTO_DIFF=%s" % os.getenv("DIAPHORA_AUTO_DIFF"))
+  debug_refresh("DIAPHORA_DB1=%s" % os.getenv("DIAPHORA_DB1"))
+  debug_refresh("DIAPHORA_DB2=%s" % os.getenv("DIAPHORA_DB2"))
+  debug_refresh("DIAPHORA_DIFF_OUT=%s" % os.getenv("DIAPHORA_DIFF_OUT"))
   if os.getenv("DIAPHORA_AUTO_DIFF") is not None:
     db1 = os.getenv("DIAPHORA_DB1")
     if db1 is None:

--- a/diaphora.py
+++ b/diaphora.py
@@ -34,6 +34,9 @@ from multiprocessing import cpu_count
 
 from diaphora_heuristics import *
 
+from pygments.lexers import NasmLexer, CppLexer, DiffLexer
+from pygments.formatters import HtmlFormatter
+
 from jkutils.kfuzzy import CKoretFuzzyHashing
 from jkutils.factor import (FACTORS_CACHE, difference, difference_ratio,
                             primesbelow as primes)
@@ -103,7 +106,7 @@ def ast_ratio(ast1, ast2):
 #-------------------------------------------------------------------------------
 def log(msg):
   if isinstance(threading.current_thread(), threading._MainThread):
-    print(("[%s] %s" % (time.asctime(), msg)))
+    print(("[diaphora][%s] %s" % (time.asctime(), msg)))
 
 #-------------------------------------------------------------------------------
 def log_refresh(msg, show=False, do_log=True):
@@ -2068,13 +2071,19 @@ class CBinDiff:
       cur.close()
     return True
 
+g_debug = False
 if __name__ == "__main__":
   version_info = sys.version_info
   if version_info[0] == 2:
     log("WARNING: You are using Python 2 instead of Python 3. The main branch of Diaphora works exclusively with Python 3.")
-    log("TIP: There are other branches that contain backward compatability.")
+    log("TIP: There are other branches that contain backward compatibility.")
 
   do_diff = True
+  if g_debug:
+    log("DIAPHORA_AUTO_DIFF=%s" % os.getenv("DIAPHORA_AUTO_DIFF"))
+    log("DIAPHORA_DB1=%s" % os.getenv("DIAPHORA_DB1"))
+    log("DIAPHORA_DB2=%s" % os.getenv("DIAPHORA_DB2"))
+    log("DIAPHORA_DIFF_OUT=%s" % os.getenv("DIAPHORA_DIFF_OUT"))
   if os.getenv("DIAPHORA_AUTO_DIFF") is not None:
     db1 = os.getenv("DIAPHORA_DB1")
     if db1 is None:

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -94,6 +94,11 @@ def log_refresh(msg, show=False, do_log=True):
     log(msg)
 
 #-------------------------------------------------------------------------------
+def debug_refresh(msg, show=False):
+  if os.getenv("DIAPHORA_DEBUG"):
+    log(msg)
+
+#-------------------------------------------------------------------------------
 # TODO: FIX hack
 diaphora.log = log
 diaphora.log_refresh = log_refresh
@@ -2803,6 +2808,7 @@ def remove_file(filename):
 #-------------------------------------------------------------------------------
 def main():
   global g_bindiff
+  # EXPORT
   if os.getenv("DIAPHORA_AUTO") is not None:
     file_out = os.getenv("DIAPHORA_EXPORT_FILE")
     if file_out is None:
@@ -2844,19 +2850,10 @@ def main():
       os.remove("%s-crash" % file_out)
 
     idaapi.qexit(0)
-  # EXPORT - works with pseudocode, better than above
-  elif os.getenv("DIAPHORA_AUTO2") is not None:
-    debug_refresh("Handling DIAPHORA_AUTO2")
-    debug_refresh("DIAPHORA_EXPORT_FILE=%s" % os.getenv("DIAPHORA_EXPORT_FILE"))
-    file_out = os.getenv("DIAPHORA_EXPORT_FILE")
-    if file_out is None:
-      raise Exception("No export file specified!")
-    _diff_or_export(False, file_out=file_out)
-    idaapi.qexit(0)
   # DIFF-SHOW
-  elif os.getenv("DIAPHORA_AUTO4") is not None:
-    debug_refresh("Handling DIAPHORA_AUTO4")
-    debug_refresh("DIAPHORA_AUTO4=%s" % os.getenv("DIAPHORA_AUTO4"))
+  elif os.getenv("DIAPHORA_AUTO_HTML") is not None:
+    debug_refresh("Handling DIAPHORA_AUTO_HTML")
+    debug_refresh("DIAPHORA_AUTO_HTML=%s" % os.getenv("DIAPHORA_AUTO_HTML"))
     debug_refresh("DIAPHORA_DB1=%s" % os.getenv("DIAPHORA_DB1"))
     debug_refresh("DIAPHORA_DB2=%s" % os.getenv("DIAPHORA_DB2"))
     debug_refresh("DIAPHORA_DIFF=%s" % os.getenv("DIAPHORA_DIFF"))

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -2801,7 +2801,7 @@ def remove_file(filename):
         cur.close()
 
 #-------------------------------------------------------------------------------
-ddef main():
+def main():
   global g_bindiff
   if os.getenv("DIAPHORA_AUTO") is not None:
     file_out = os.getenv("DIAPHORA_EXPORT_FILE")

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -78,7 +78,7 @@ LITTLE_ORANGE = 0x026AFD
 
 #-------------------------------------------------------------------------------
 def log(message):
-  msg("[%s] %s\n" % (time.asctime(), message))
+  msg("[diaphora_ida][%s] %s\n" % (time.asctime(), message))
 
 #-------------------------------------------------------------------------------
 def log_refresh(msg, show=False, do_log=True):
@@ -965,7 +965,7 @@ class CIDABinDiff(diaphora.CBinDiff):
     self.import_til()
     self.import_definitions()
 
-  def show_asm_diff(self, item):
+  def generate_asm_diff(self, ea1, ea2, error_func=log):
     cur = self.db_cursor()
     sql = """select *
                from (
@@ -978,12 +978,13 @@ class CIDABinDiff(diaphora.CBinDiff):
               where address = ?
                 and assembly is not null)
               order by 4 asc"""
-    ea1 = str(int(item[1], 16))
-    ea2 = str(int(item[3], 16))
+    ea1 = str(int(ea1, 16))
+    ea2 = str(int(ea2, 16))
     cur.execute(sql, (ea1, ea2))
     rows = cur.fetchall()
+    res = None
     if len(rows) != 2:
-      warning("Sorry, there is no assembly available for either the first or the second database.")
+      error_func("Sorry, there is no assembly available for either the first or the second database.")
     else:
       row1 = rows[0]
       row2 = rows[1]
@@ -993,7 +994,7 @@ class CIDABinDiff(diaphora.CBinDiff):
       asm2 = self.prettify_asm(row2["assembly"])
       buf1 = "%s proc near\n%s\n%s endp" % (row1["name"], asm1, row1["name"])
       buf2 = "%s proc near\n%s\n%s endp" % (row2["name"], asm2, row2["name"])
-      
+
       fmt = HtmlFormatter()
       fmt.noclasses = True
       fmt.linenos = False
@@ -1001,10 +1002,23 @@ class CIDABinDiff(diaphora.CBinDiff):
       src = html_diff.make_file(buf1.split("\n"), buf2.split("\n"), fmt, NasmLexer())
 
       title = "Diff assembler %s - %s" % (row1["name"], row2["name"])
+      res = (src, title)
+
+    cur.close()
+    return res
+
+  def show_asm_diff(self, item):
+    res = self.generate_asm_diff(item[1], item[3], error_func=warning)
+    if res:
+      (src, title) = res
       cdiffer = CHtmlViewer()
       cdiffer.Show(src, title)
 
-    cur.close()
+  def save_asm_diff(self, ea1, ea2, filename):
+    res = self.generate_asm_diff(ea1, ea2)
+    if res:
+      (src, _) = res
+      open(filename, "w").write(src)
 
   def import_one(self, item):
     ret = ask_yn(1, "AUTOHIDE DATABASE\nDo you want to import all the type libraries, structs and enumerations?")
@@ -1079,7 +1093,7 @@ class CIDABinDiff(diaphora.CBinDiff):
       cdiffer.Show(src, title)
     cur.close()
 
-  def show_pseudo_diff(self, item, html = True):
+  def generate_pseudo_diff(self, ea1, ea2, html = True, error_func=log):
     cur = self.db_cursor()
     sql = """select *
                from (
@@ -1092,12 +1106,13 @@ class CIDABinDiff(diaphora.CBinDiff):
               where address = ?
                 and pseudocode is not null)
               order by 4 asc"""
-    ea1 = str(int(item[1], 16))
-    ea2 = str(int(item[3], 16))
+    ea1 = str(int(ea1, 16))
+    ea2 = str(int(ea2, 16))
     cur.execute(sql, (ea1, ea2))
     rows = cur.fetchall()
+    res = None
     if len(rows) != 2:
-      warning("Sorry, there is no pseudo-code available for either the first or the second database.")
+      error_func("Sorry, there is no pseudo-code available for either the first or the second database.")
     else:
       row1 = rows[0]
       row2 = rows[1]
@@ -1112,7 +1127,7 @@ class CIDABinDiff(diaphora.CBinDiff):
       buf2 = row2["prototype"] + "\n" + row2["pseudocode"]
 
       if buf1 == buf2:
-        warning("Both pseudo-codes are equal.")
+        error_func("Both pseudo-codes are equal.")
 
       fmt = HtmlFormatter()
       fmt.noclasses = True
@@ -1125,16 +1140,29 @@ class CIDABinDiff(diaphora.CBinDiff):
           tmp.append(line.strip("\n"))
         tmp = tmp[2:]
         buf = "\n".join(tmp)
-        
+
         src = highlight(buf, DiffLexer(), fmt)
       else:
         src = html_diff.make_file(buf2.split("\n"), buf1.split("\n"), fmt, CppLexer())
 
       title = "Diff pseudo-code %s - %s" % (row2["name"], row1["name"])
+      res = (src, title)
+
+    cur.close()
+    return res
+
+  def show_pseudo_diff(self, item, html = True):
+    res = self.generate_pseudo_diff(item[1], item[3], html=html, error_func=warning)
+    if res:
+      (src, title) = res
       cdiffer = CHtmlViewer()
       cdiffer.Show(src, title)
 
-    cur.close()
+  def save_pseudo_diff(self, ea1, ea2, filename):
+    res = self.generate_pseudo_diff(ea1, ea2, html=True)
+    if res:
+      (src, _) = res
+      open(filename, "w").write(src)
 
   def diff_external(self, item):
     cmd_line = None
@@ -2574,6 +2602,16 @@ def _diff_or_export(use_ui, **options):
 
   return bd
 
+# XXX - db2 is unused so could be removed?
+def _generate_html(db1, db2, diff_db, ea1, ea2, html_asm, html_pseudo):
+    bd = CIDABinDiff(db1)
+    bd.db = sqlite3.connect(db1, check_same_thread=True)
+    bd.db.text_factory = str
+    bd.db.row_factory = sqlite3.Row
+    bd.load_results(diff_db)
+    bd.save_pseudo_diff(ea1, ea2, html_pseudo)
+    bd.save_asm_diff(ea1, ea2, html_asm)
+
 #-------------------------------------------------------------------------------
 class BinDiffOptions:
   def __init__(self, **kwargs):
@@ -2763,6 +2801,7 @@ def remove_file(filename):
         cur.close()
 
 #-------------------------------------------------------------------------------
+g_debug = False
 def main():
   global g_bindiff
   if os.getenv("DIAPHORA_AUTO") is not None:
@@ -2805,6 +2844,51 @@ def main():
       log("Aborted by user, removing crash file %s-crash..." % file_out)
       os.remove("%s-crash" % file_out)
 
+    idaapi.qexit(0)
+  # EXPORT - works with pseudocode, better than above
+  elif os.getenv("DIAPHORA_AUTO2") is not None:
+    if g_debug:
+      log("Handling DIAPHORA_AUTO2")
+      log("DIAPHORA_EXPORT_FILE=%s" % os.getenv("DIAPHORA_EXPORT_FILE"))
+    file_out = os.getenv("DIAPHORA_EXPORT_FILE")
+    if file_out is None:
+      raise Exception("No export file specified!")
+    _diff_or_export(False, file_out=file_out)
+    idaapi.qexit(0)
+  # DIFF-SHOW
+  elif os.getenv("DIAPHORA_AUTO4") is not None:
+    if g_debug:
+      log("Handling DIAPHORA_AUTO4")
+      log("DIAPHORA_AUTO4=%s" % os.getenv("DIAPHORA_AUTO4"))
+      log("DIAPHORA_DB1=%s" % os.getenv("DIAPHORA_DB1"))
+      log("DIAPHORA_DB2=%s" % os.getenv("DIAPHORA_DB2"))
+      log("DIAPHORA_DIFF=%s" % os.getenv("DIAPHORA_DIFF"))
+      log("DIAPHORA_EA1=%s" % os.getenv("DIAPHORA_EA1"))
+      log("DIAPHORA_EA2=%s" % os.getenv("DIAPHORA_EA2"))
+      log("DIAPHORA_HTML_ASM=%s" % os.getenv("DIAPHORA_HTML_ASM"))
+      log("DIAPHORA_HTML_PSEUDO=%s" % os.getenv("DIAPHORA_HTML_PSEUDO"))
+    db1 = os.getenv("DIAPHORA_DB1")
+    if db1 is None:
+      raise Exception("No database file specified!")
+    db2 = os.getenv("DIAPHORA_DB2")
+    if db2 is None:
+      raise Exception("No database file to diff against specified!")
+    diff_db = os.getenv("DIAPHORA_DIFF")
+    if diff_db is None:
+      raise Exception("No diff database file for diff specified!")
+    ea1 = os.getenv("DIAPHORA_EA1")
+    if ea1 is None:
+      raise Exception("No address 1 specified!")
+    ea2 = os.getenv("DIAPHORA_EA2")
+    if ea2 is None:
+      raise Exception("No address 2 specified!")
+    html_asm = os.getenv("DIAPHORA_HTML_ASM")
+    if html_asm is None:
+      raise Exception("No html output file for asm specified!")
+    html_pseudo = os.getenv("DIAPHORA_HTML_PSEUDO")
+    if html_pseudo is None:
+      raise Exception("No html output file for pseudo specified!")
+    _generate_html(db1, db2, diff_db, ea1, ea2, html_asm, html_pseudo)
     idaapi.qexit(0)
   else:
     _diff_or_export(True)

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -78,7 +78,7 @@ LITTLE_ORANGE = 0x026AFD
 
 #-------------------------------------------------------------------------------
 def log(message):
-  msg("[diaphora_ida][%s] %s\n" % (time.asctime(), message))
+  msg("[diaphora][%s] %s\n" % (time.asctime(), message))
 
 #-------------------------------------------------------------------------------
 def log_refresh(msg, show=False, do_log=True):
@@ -2604,13 +2604,13 @@ def _diff_or_export(use_ui, **options):
 
 # XXX - db2 is unused so could be removed?
 def _generate_html(db1, db2, diff_db, ea1, ea2, html_asm, html_pseudo):
-    bd = CIDABinDiff(db1)
-    bd.db = sqlite3.connect(db1, check_same_thread=True)
-    bd.db.text_factory = str
-    bd.db.row_factory = sqlite3.Row
-    bd.load_results(diff_db)
-    bd.save_pseudo_diff(ea1, ea2, html_pseudo)
-    bd.save_asm_diff(ea1, ea2, html_asm)
+  bd = CIDABinDiff(db1)
+  bd.db = sqlite3.connect(db1, check_same_thread=True)
+  bd.db.text_factory = str
+  bd.db.row_factory = sqlite3.Row
+  bd.load_results(diff_db)
+  bd.save_pseudo_diff(ea1, ea2, html_pseudo)
+  bd.save_asm_diff(ea1, ea2, html_asm)
 
 #-------------------------------------------------------------------------------
 class BinDiffOptions:
@@ -2801,8 +2801,7 @@ def remove_file(filename):
         cur.close()
 
 #-------------------------------------------------------------------------------
-g_debug = False
-def main():
+ddef main():
   global g_bindiff
   if os.getenv("DIAPHORA_AUTO") is not None:
     file_out = os.getenv("DIAPHORA_EXPORT_FILE")
@@ -2847,9 +2846,8 @@ def main():
     idaapi.qexit(0)
   # EXPORT - works with pseudocode, better than above
   elif os.getenv("DIAPHORA_AUTO2") is not None:
-    if g_debug:
-      log("Handling DIAPHORA_AUTO2")
-      log("DIAPHORA_EXPORT_FILE=%s" % os.getenv("DIAPHORA_EXPORT_FILE"))
+    debug_refresh("Handling DIAPHORA_AUTO2")
+    debug_refresh("DIAPHORA_EXPORT_FILE=%s" % os.getenv("DIAPHORA_EXPORT_FILE"))
     file_out = os.getenv("DIAPHORA_EXPORT_FILE")
     if file_out is None:
       raise Exception("No export file specified!")
@@ -2857,16 +2855,15 @@ def main():
     idaapi.qexit(0)
   # DIFF-SHOW
   elif os.getenv("DIAPHORA_AUTO4") is not None:
-    if g_debug:
-      log("Handling DIAPHORA_AUTO4")
-      log("DIAPHORA_AUTO4=%s" % os.getenv("DIAPHORA_AUTO4"))
-      log("DIAPHORA_DB1=%s" % os.getenv("DIAPHORA_DB1"))
-      log("DIAPHORA_DB2=%s" % os.getenv("DIAPHORA_DB2"))
-      log("DIAPHORA_DIFF=%s" % os.getenv("DIAPHORA_DIFF"))
-      log("DIAPHORA_EA1=%s" % os.getenv("DIAPHORA_EA1"))
-      log("DIAPHORA_EA2=%s" % os.getenv("DIAPHORA_EA2"))
-      log("DIAPHORA_HTML_ASM=%s" % os.getenv("DIAPHORA_HTML_ASM"))
-      log("DIAPHORA_HTML_PSEUDO=%s" % os.getenv("DIAPHORA_HTML_PSEUDO"))
+    debug_refresh("Handling DIAPHORA_AUTO4")
+    debug_refresh("DIAPHORA_AUTO4=%s" % os.getenv("DIAPHORA_AUTO4"))
+    debug_refresh("DIAPHORA_DB1=%s" % os.getenv("DIAPHORA_DB1"))
+    debug_refresh("DIAPHORA_DB2=%s" % os.getenv("DIAPHORA_DB2"))
+    debug_refresh("DIAPHORA_DIFF=%s" % os.getenv("DIAPHORA_DIFF"))
+    debug_refresh("DIAPHORA_EA1=%s" % os.getenv("DIAPHORA_EA1"))
+    debug_refresh("DIAPHORA_EA2=%s" % os.getenv("DIAPHORA_EA2"))
+    debug_refresh("DIAPHORA_HTML_ASM=%s" % os.getenv("DIAPHORA_HTML_ASM"))
+    debug_refresh("DIAPHORA_HTML_PSEUDO=%s" % os.getenv("DIAPHORA_HTML_PSEUDO"))
     db1 = os.getenv("DIAPHORA_DB1")
     if db1 is None:
       raise Exception("No database file specified!")


### PR DESCRIPTION
An example of use for this is in idahunt. See detailed example in https://github.com/nccgroup/idahunt#binary-diffing where it shows how IDA is called and what environment variables are set. We obtain https://github.com/nccgroup/idahunt/blob/main/img/TmRecoverResourceManagerExt.png

The code changes consists in:
- distinguishing the code generation (assembly and pseudo code) from showing it in IDA, so we can generate the code from the command line without showing it
- support more DIAPHORA_AUTO + other environment variables to call it from the command line