### PR TITLE
Fix: Some environment variables working properly.

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -221,13 +221,9 @@ class CBinDiff:
     self.relaxed_ratio = self.get_value_for("relaxed_ratio", False)
     self.experimental = self.get_value_for("experimental", False)
     self.slow_heuristics = self.get_value_for("slow_heuristics", False)
+    self.use_decompiler_always = self.get_value_for("use_decompiler_always", True)
+    self.exclude_library_thunk = self.get_value_for("exclude_library_thunk", True)
 
-    self.unreliable = False
-    self.relaxed_ratio = False
-    self.experimental = False
-    self.slow_heuristics = False
-    self.use_decompiler_always = True
-    self.exclude_library_thunk = True
     self.project_script = None
     self.hooks = None
 


### PR DESCRIPTION
Some environment variables not working, after https://github.com/joxeankoret/diaphora/commit/5fe0cc0fab9982ea43fa4905f27dc1ada9883437
- DIAPHORA_UNRELIABLE
- DIAPHORA_RELAXED_RATIO
- DIAPHORA_EXPERIMENTAL
- DIAPHORA_SLOW_HEURISTICS

Just fix them, and add two new environment variables:
- DIAPHORA_USE_DECOMPILER_ALWAYS
- DIAPHORA_EXCLUDE_LIBRARY_THUNK