### PR TITLE
Parallel export

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -52,6 +52,8 @@ from diaphora_heuristics import (
   get_query_fields,
 )
 
+from diaphora_sql import InsertInto, NATIVE, MICROCODE
+
 import db_support
 from db_support import schema
 
@@ -340,6 +342,7 @@ class CBinDiff:
     self.dbs_dict = {}
     self.db = None  # Used exclusively by the exporter!
     self.open_db()
+    self.insert_into = InsertInto()
 
     self.all_matches = {"best": [], "partial": [], "unreliable": []}
     self.matched_primary = {}
@@ -679,11 +682,6 @@ class CBinDiff:
     database.
     """
     instructions_ids = {}
-    sql = """insert into main.instructions (address, mnemonic, disasm,
-                      comment1, comment2, operand_names, name,
-                      type, pseudocomment, pseudoitp, func_id,
-                      asm_type)
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'native')"""
     cur_execute = cur.execute
     for key in bb_data:
       for instruction in bb_data[key]:
@@ -709,7 +707,7 @@ class CBinDiff:
         instruction_properties.append(pseudocomment)
         instruction_properties.append(pseudoitp)
         instruction_properties.append(func_id)
-        cur.execute(sql, instruction_properties)
+        self.insert_into.main_instructions(cur_execute, instruction_properties, NATIVE)
         db_id = cur.lastrowid
         instructions_ids[addr] = db_id
     return cur_execute, instructions_ids
@@ -723,8 +721,6 @@ class CBinDiff:
     """
     num = 0
     bb_ids = {}
-    sql1 = "insert into main.basic_blocks (num, address, asm_type) values (?, ?, 'native')"
-    sql2 = "insert into main.bb_instructions (basic_block_id, instruction_id) values (?, ?)"
 
     self_get_bb_id = self.get_bb_id
     for key in bb_data:
@@ -733,31 +729,29 @@ class CBinDiff:
       ins_ea = str(key)
       last_bb_id = self_get_bb_id(ins_ea)
       if last_bb_id is None:
-        cur_execute(sql1, (num, str(ins_ea)))
+        self.insert_into.main_basic_blocks(cur_execute, (num, str(ins_ea)), NATIVE)
         last_bb_id = cur.lastrowid
       bb_ids[ins_ea] = last_bb_id
 
       # Insert relations between basic blocks and instructions
       for instruction in bb_data[key]:
         ins_id = instructions_ids[instruction[0]]
-        cur_execute(sql2, (last_bb_id, ins_id))
+        self.insert_into.main_bb_instructions(cur_execute, (last_bb_id, ins_id), NATIVE)
 
     # Insert relations between basic blocks
-    sql = "insert into main.bb_relations (parent_id, child_id) values (?, ?)"
     for key in bb_relations:
       for bb in bb_relations[key]:
         bb = str(bb)
         key = str(key)
         try:
-          cur_execute(sql, (bb_ids[key], bb_ids[bb]))
+          self.insert_into.main_bb_relations(cur_execute, (bb_ids[key], bb_ids[bb]), NATIVE)
         except:
           # key doesnt exist because it doesnt have forward references to any bb
           log(f"Error: {str(sys.exc_info()[1])}")
 
     # And finally insert the functions to basic blocks relations
-    sql = "insert into main.function_bblocks (function_id, basic_block_id, asm_type) values (?, ?, 'native')"
     for key, bb_id in bb_ids.items():
-      cur_execute(sql, (func_id, bb_id))
+      self.insert_into.main_function_bblocks(cur_execute, (func_id, bb_id), NATIVE)
 
   def save_microcode_instructions(
     self, func_id, cur, cur_execute, microcode_bblocks, microcode_bbrelations
@@ -765,25 +759,16 @@ class CBinDiff:
     """
     Save all the microcode instructions in the basic block @bb_data to the database.
     """
-    sql_inst = """insert into main.instructions (address, mnemonic, disasm, comment1,
-                         pseudocomment, func_id, asm_type)
-                values (?, ?, ?, ?, ?, ?, 'microcode')"""
-    sql_bblock = "insert into main.basic_blocks (num, address, asm_type) values (?, ?, 'microcode')"
-    sql_bbinst = "insert into main.bb_instructions (basic_block_id, instruction_id) values (?, ?)"
-    sql_bbrelations = (
-      "insert into main.bb_relations (parent_id, child_id) values (?, ?)"
-    )
-    sql_func_blocks = "insert into main.function_bblocks (function_id, basic_block_id, asm_type) values (?, ?, 'microcode')"
     num = 0
     for key in microcode_bblocks:
       # Create a new microcode basic block
       start_ea = self.get_valid_prop(microcode_bblocks[key]["start"])
-      cur_execute(sql_bblock, [num, start_ea])
+      self.insert_into.main_basic_blocks(cur_execute, [num, start_ea], MICROCODE)
       bblock_id = cur.lastrowid
       microcode_bblocks[key]["bblock_id"] = bblock_id
 
       # Add the function -> basic block relation
-      cur_execute(sql_func_blocks, (func_id, bblock_id))
+      self.insert_into.main_function_bblocks(cur_execute, (func_id, bblock_id), MICROCODE)
 
       for line in microcode_bblocks[key]["lines"]:
         if line["mnemonic"] is not None:
@@ -802,13 +787,13 @@ class CBinDiff:
             pseudocomment,
             func_id,
           ]
-          cur_execute(sql_inst, arguments)
+          self.insert_into.main_instructions(cur_execute, arguments, MICROCODE)
 
           inst_id = cur.lastrowid
           line["instruction_id"] = inst_id
 
           # Add the microcode instrution to the current basic block
-          cur_execute(sql_bbinst, (bblock_id, inst_id))
+          self.insert_into.main_bb_instructions(cur_execute, (bblock_id, inst_id), MICROCODE)
 
       # Incrase the current basic block number
       num += 1
@@ -821,7 +806,7 @@ class CBinDiff:
         # with them, just ignore...
         if children in microcode_bblocks:
           child_id = microcode_bblocks[children]["bblock_id"]
-          cur_execute(sql_bbrelations, [parent_id, child_id])
+          self.insert_into.main_bb_relations(cur_execute, [parent_id, child_id], MICROCODE)
 
   def get_function_from_dictionary(self, d):
     """
@@ -1045,25 +1030,8 @@ class CBinDiff:
         else:
           new_props.append(prop)
 
-      sql = """insert into main.functions (name, nodes, edges, indegree, outdegree, size,
-                    instructions, mnemonics, names, prototype,
-                    cyclomatic_complexity, primes_value, address,
-                    comment, mangled_function, bytes_hash, pseudocode,
-                    pseudocode_lines, pseudocode_hash1, pseudocode_primes,
-                    function_flags, assembly, prototype2, pseudocode_hash2,
-                    pseudocode_hash3, strongly_connected, loops, rva,
-                    tarjan_topological_sort, strongly_connected_spp,
-                    clean_assembly, clean_pseudo, mnemonics_spp, switches,
-                    function_hash, bytes_sum, md_index, constants,
-                    constants_count, segment_rva, assembly_addrs, kgh_hash,
-                    source_file, userdata, microcode, clean_microcode,
-                    microcode_spp)
-                  values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
-
       try:
-        cur.execute(sql, new_props)
+        self.insert_into.main_functions(cur.execute, new_props)
       except:
         logging.error(
           "Error handling props in save_function(): %s", str(new_props)
@@ -1077,15 +1045,13 @@ class CBinDiff:
 
       # Phase 2: Save the callers and callees of the function
       callers, callees = props[len(props) - 4:len(props) - 2]
-      sql = "insert into callgraph (func_id, address, type) values (?, ?, ?)"
       for caller in callers:
-        cur.execute(sql, (func_id, str(caller), "caller"))
+        self.insert_into.callgraph(cur.execute, (func_id, str(caller), "caller"))
 
       for callee in callees:
-        cur.execute(sql, (func_id, str(callee), "callee"))
+        self.insert_into.callgraph(cur.execute, (func_id, str(callee), "callee"))
 
       # Phase 3: Insert the constants of the function
-      sql = "insert into constants (func_id, constant) values (?, ?)"
       props_dict = self.create_function_dictionary(props)
       for constant in props_dict["constants"]:
         should_add = False
@@ -1096,7 +1062,7 @@ class CBinDiff:
           constant = str(constant)
 
         if should_add:
-          cur.execute(sql, (func_id, constant))
+          self.insert_into.constants(cur.execute, (func_id, constant))
 
       # Phase 4: Save the basic blocks relationships
       if not self.function_summaries_only:

--- a/diaphora_config.py
+++ b/diaphora_config.py
@@ -8,6 +8,8 @@ to add your own code here.
 ################################################################################
 # Imports required by the configuration file
 import os
+from queue import Queue
+from typing import Optional, Tuple
 
 CONFIGURATION_FILE_PATH = os.path.realpath(__file__)
 CONFIGURATION_DIRECTORY = os.path.dirname(CONFIGURATION_FILE_PATH)
@@ -164,3 +166,10 @@ RUN_DEFAULT_SCRIPTS = True
 
 # Where is the default patch diffing script?
 DEFAULT_SCRIPT_PATCH_DIFF = os.path.join(CONFIGURATION_DIRECTORY, "scripts/patch_diff_vulns.py")
+
+# Parallel Export
+PARALLEL_EXPORT: bool = False  # default to sequential export
+PARALLEL_JOB_QUEUE: Optional[Queue[Tuple[int, int]]] = None
+PARALLEL_REPORT_QUEUE: Optional[Queue[Tuple[int, int]]] = None
+WORKER_ID: int = 0  # ID of current worker
+NUMBER_OF_WORKERS: int = 1

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -1124,6 +1124,7 @@ class CIDABinDiff(diaphora.CBinDiff):
     log("Exporting range 0x%08x - 0x%08x" % (self.min_ea, self.max_ea))
     func_list = set(Functions(self.min_ea, self.max_ea))
     total_funcs = len(func_list)
+    log_step = (total_funcs + 127) // 128  # log every `log_step` functions
     self._funcs_cache = {}
     t = time.monotonic()
 
@@ -1148,7 +1149,7 @@ class CIDABinDiff(diaphora.CBinDiff):
         raise Exception("Canceled.")
 
       i += 1
-      if (total_funcs >= 100) and i % (int(total_funcs / 100)) == 0 or i == 1:
+      if (i-1) % log_step == 0:
         line = "Exported %d function(s) out of %d total.\nElapsed %d:%02d:%02d second(s), remaining time ~%d:%02d:%02d"
         elapsed = time.monotonic() - t
         remaining = (elapsed / i) * (total_funcs - i)
@@ -1157,9 +1158,8 @@ class CIDABinDiff(diaphora.CBinDiff):
         h, m = divmod(m, 60)
         m_elapsed, s_elapsed = divmod(elapsed, 60)
         h_elapsed, m_elapsed = divmod(m_elapsed, 60)
-        replace_wait_box(
-          line % (i, total_funcs, h_elapsed, m_elapsed, s_elapsed, h, m, s)
-        )
+        message = line % (i, total_funcs, h_elapsed, m_elapsed, s_elapsed, h, m, s)
+        replace_wait_box(message)
 
       self.microcode_ins_list = self.get_microcode_instructions()
       props = self.read_function(func)

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -1114,7 +1114,35 @@ class CIDABinDiff(diaphora.CBinDiff):
   def filter_functions(self, functions: Set[int]) -> Iterable[int]:
     # filter functions to export
     # Useful for parallel fork
-    return (functions - self._funcs_cache.keys())
+    if not config.PARALLEL_EXPORT:
+      result = (functions - self._funcs_cache.keys())
+      yield from result
+      return
+
+    if config.WORKER_ID == config.NUMBER_OF_WORKERS:
+      return
+
+    job_id, nbr_of_jobs = config.PARALLEL_JOB_QUEUE.get()
+    number_of_functions_per_job = (len(functions) + nbr_of_jobs-1)//nbr_of_jobs
+
+    sorted_functions_list = sorted(functions)
+    while job_id >=0:
+      print(f"[{config.WORKER_ID}/{config.NUMBER_OF_WORKERS}] processing job {job_id}")
+      first_function = job_id * number_of_functions_per_job
+      last_function = (job_id + 1) * number_of_functions_per_job
+      if job_id + 1 == nbr_of_jobs:
+        # make sure last job analyze last function
+        last_function += 1
+
+      for func in sorted_functions_list[first_function:last_function]:
+        if func not in self._funcs_cache:
+          yield func
+
+      # Report and wait for next job
+      config.PARALLEL_REPORT_QUEUE.put((config.WORKER_ID, job_id))
+      job_id, _ = config.PARALLEL_JOB_QUEUE.get()
+
+    print(f"[{config.WORKER_ID}/{config.NUMBER_OF_WORKERS}] done")
 
   def do_export(self, crashed_before=False):
     """
@@ -1159,7 +1187,10 @@ class CIDABinDiff(diaphora.CBinDiff):
         m_elapsed, s_elapsed = divmod(elapsed, 60)
         h_elapsed, m_elapsed = divmod(m_elapsed, 60)
         message = line % (i, total_funcs, h_elapsed, m_elapsed, s_elapsed, h, m, s)
-        replace_wait_box(message)
+        if config.PARALLEL_EXPORT:
+          print(message)
+        else:
+          replace_wait_box(message)
 
       self.microcode_ins_list = self.get_microcode_instructions()
       props = self.read_function(func)
@@ -1184,6 +1215,9 @@ class CIDABinDiff(diaphora.CBinDiff):
         self.db.execute("PRAGMA synchronous = OFF")
         self.db.execute("PRAGMA journal_mode = MEMORY")
         self.db.execute("BEGIN transaction")
+
+    if config.PARALLEL_EXPORT and config.WORKER_ID < config.NUMBER_OF_WORKERS:
+      return
 
     md5sum = GetInputFileMD5()
     self.save_callgraph(
@@ -3947,7 +3981,7 @@ def main():
     _generate_html(db1, diff_db, ea1, ea2, html_asm, html_pseudo)
     idaapi.qexit(0)
   else:
-    _diff_or_export(True)
+    _diff_or_export(not config.PARALLEL_EXPORT)
 
 
 if __name__ == "__main__":

--- a/diaphora_parallel_export.py
+++ b/diaphora_parallel_export.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python3
+
+import os
+import secrets
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from base64 import b64encode
+from concurrent.futures import ThreadPoolExecutor, wait
+from multiprocessing.managers import BaseManager
+from pathlib import Path
+from queue import Queue
+from random import randrange
+from time import time
+from typing import Optional, Tuple, cast
+
+IDA = os.getenv("IDADIR") + "idat64"
+DIAPHORA = str(Path("diaphora.py").resolve())
+DIAPHORA_DIR = str(Path(".").resolve())
+
+###############################################
+# Database merge taken from
+# https://stackoverflow.com/a/68526717
+
+
+def merge_databases(db1: str, db2: str) -> None:
+    print(f"Merging {db2} into {db1}")
+    con3 = sqlite3.connect(db1)
+
+    con3.execute("ATTACH '" + db2 + "' as dba")
+
+    con3.execute("BEGIN")
+    for row in con3.execute("SELECT * FROM dba.sqlite_master WHERE type='table'"):
+        combine = "INSERT OR IGNORE INTO " + row[1] + " SELECT * FROM dba." + row[1]
+        con3.execute(combine)
+    con3.commit()
+    con3.execute("detach database dba")
+    con3.close()
+
+
+###############################################
+
+
+def get_idb(target: Path) -> Path:
+    target_idb = target.parent / (target.name + ".i64")
+    if not target_idb.exists():
+        subprocess.run(
+            [IDA, "-Llog.txt", "-B", str(target)],
+            env={
+                "TVHEADLESS": "1",
+                "HOME": os.getenv("HOME", ""),
+                "IDAUSR": os.getenv("IDAUSR", ""),
+            },
+        )
+    return target_idb
+
+
+def start_exporter(args: Tuple[Path, Path, int, int, int, bytes]) -> int:
+    tmpdir, source_idb, worker_id, nbr_of_workers, port, authkey = args
+    target = tmpdir / (source_idb.name[: -len(".i64")] + str(worker_id) + ".i64")
+    shutil.copyfile(source_idb, target)
+    os.system(
+        "TVHEADLESS=1 "
+        f'PYTHON_PATH=$PYTHON_PATH:"{DIAPHORA_DIR}" '
+        "~/idapro-8.2/./idat64 -a -A "
+        f'-S"{DIAPHORA} {worker_id} {nbr_of_workers} {port} {b64encode(authkey).decode("ASCII")}" '
+        f"-Llog.txt "
+        f"{target}"
+    )
+    target.unlink()
+    print(f"Worker {worker_id} done")
+    return worker_id
+
+
+class QueueManager(BaseManager):
+    pass
+
+
+def start_queues() -> Tuple[QueueManager, int, bytes]:
+    job_queue: Queue[Tuple[int, int]] = Queue()
+    report_queue: Queue[int] = Queue()
+
+    QueueManager.register("get_job_queue", callable=lambda: job_queue)
+    QueueManager.register("get_report_queue", callable=lambda: report_queue)
+
+    m: Optional[QueueManager] = None
+    port = randrange(49152, 65536)
+    authkey = secrets.token_bytes()
+
+    while m is None:
+        try:
+            m = QueueManager(address=("localhost", port), authkey=authkey)
+            m.start()
+        except Exception:
+            m = None
+            port = randrange(49152, 65536)
+
+    return m, port, authkey
+
+
+def merge_while_exporting(
+    qm: QueueManager, number_of_workers: int, number_of_jobs: int
+) -> Tuple[Path, int]:
+    # merge as soon as exports are done and return path to merged db
+    assert number_of_workers > 0
+    db_files = [
+        str(tmpdir / f"{target.name}{i}.sqlite") for i in range(number_of_workers)
+    ]
+    remaining_workers = {i for i in range(number_of_workers)}
+    main_worker: Optional[int] = None
+
+    while remaining_workers:
+        worker_id, report = cast(Tuple[int, int], qm.get_report_queue().get())
+        if report >= 0:
+            print(f"Job {report} done by worker {worker_id}")
+            continue
+
+        if main_worker is None:
+            main_worker = worker_id
+        else:
+            merge_databases(db_files[main_worker], db_files[worker_id])
+        remaining_workers.discard(worker_id)
+
+    # merge into last worker db
+    assert main_worker is not None
+
+    return Path(db_files[main_worker]), main_worker
+
+
+if __name__ == "__main__":
+    start = time()
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file> [<nbr workers>] [<nbr jobs>]")
+    target = Path(sys.argv[1]).resolve()
+    target_idb = get_idb(target)
+    print(f"idb retrieved in {time() - start:.3f} seconds")
+
+    number_of_workers = (os.cpu_count() or 4) - 1
+    if len(sys.argv) > 2:
+        number_of_workers = int(sys.argv[2])
+    number_of_jobs = 2 * number_of_workers
+    if len(sys.argv) > 3:
+        number_of_jobs = int(sys.argv[3])
+
+    assert number_of_jobs >= number_of_workers > 0
+
+    queue_manager, port, authkey = start_queues()
+
+    print(f"Starting {number_of_jobs} jobs on {number_of_workers} workers")
+
+    with tempfile.TemporaryDirectory(dir=target.parent) as tmpdirname:
+        tmpdir = Path(tmpdirname)
+        print("Working in ", tmpdir)
+
+        with ThreadPoolExecutor(max_workers=number_of_workers) as pool:
+            futures = [
+                pool.submit(
+                    start_exporter,
+                    (tmpdir, target_idb, i, number_of_workers, port, authkey),
+                )
+                for i in range(number_of_workers)
+            ]
+
+            # send jobs
+            for i in range(number_of_jobs):
+                print(f"Sending job {i} of {number_of_jobs}")
+                queue_manager.get_job_queue().put((i, number_of_jobs))
+
+            # send kill switches
+            for i in range(number_of_workers):
+                print(f"Sending killswitch {i}")
+                queue_manager.get_job_queue().put((-1, number_of_jobs))
+
+            # Start merging results asap
+            merged_database, last_worker = merge_while_exporting(
+                queue_manager, number_of_workers, number_of_jobs
+            )
+            print(f"Functions exported in {time() - start:.3f} seconds")
+
+            wait(futures)
+
+        # Run diaphora one more time to get global info
+        print("Finalizing database...")
+        (merged_database.parent / (merged_database.name + "-crash")).touch()
+        start_exporter((tmpdir, target_idb, last_worker, last_worker, port, authkey))
+        print(f"Database exported in {time() - start:.3f} seconds")
+        merged_database.rename(target.parent / f"{target.name}.sqlite")
+
+    queue_manager.shutdown()

--- a/diaphora_sql.py
+++ b/diaphora_sql.py
@@ -1,0 +1,163 @@
+from typing import Any, Callable, List
+
+NATIVE = "native"
+MICROCODE = "microcode"
+
+
+class InsertInto:
+    """All queries related to the export of information on individual functions
+    """
+    def __execute(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        table: str,
+        column_names: str,
+        column_defaults: str,
+        column_values: List[Any],
+    ) -> None:
+        cur_execute(
+            f"insert into {table} ({column_names}) values ({column_defaults})",
+            column_values,
+        )
+
+    def main_instructions(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+        obj_type: str = NATIVE,
+    ) -> None:
+        table = "main.instructions"
+        if obj_type == NATIVE:
+            column_names = (
+                "address, mnemonic, disasm, comment1, "
+                "comment2, operand_names, name, type, "
+                "pseudocomment, "
+                "pseudoitp, "
+                "func_id, asm_type"
+            )
+            column_defaults = "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'native'"
+        elif obj_type == MICROCODE:
+            column_names = (
+                "address, mnemonic, disasm, comment1, "
+                "pseudocomment, "
+                "func_id, asm_type"
+            )
+            column_defaults = "?, ?, ?, ?, ?, ?, 'microcode'"
+        else:
+            raise ValueError(f"Unknown type '{obj_type}'")
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def main_basic_blocks(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+        obj_type: str = NATIVE,
+    ) -> None:
+        table = "main.basic_blocks"
+        if obj_type in {NATIVE, MICROCODE}:
+            column_names = "num, address, asm_type"
+            column_defaults = f"?, ?, '{obj_type}'"
+        else:
+            raise ValueError(f"Unknown type '{obj_type}'")
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def main_bb_instructions(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+        obj_type: str = NATIVE,
+    ) -> None:
+        table = "main.bb_instructions"
+        column_names = "basic_block_id, instruction_id"
+        column_defaults = "?, ?"
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def main_bb_relations(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+        obj_type: str = NATIVE,
+    ) -> None:
+        table = "main.bb_relations"
+        column_names = "parent_id, child_id"
+        column_defaults = "?, ?"
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def main_function_bblocks(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+        obj_type: str = NATIVE,
+    ) -> None:
+        table = "main.function_bblocks"
+        if obj_type in {NATIVE, MICROCODE}:
+            column_names = "function_id, basic_block_id, asm_type"
+            column_defaults = f"?, ?, '{obj_type}'"
+        else:
+            raise ValueError(f"Unknown type '{obj_type}'")
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def main_functions(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+    ) -> None:
+        table = "main.functions"
+        column_names = (
+            "name, nodes, edges, indegree, outdegree, size, "
+            "instructions, mnemonics, names, prototype, "
+            "cyclomatic_complexity, primes_value, address, "
+            "comment, mangled_function, bytes_hash, pseudocode, "
+            "pseudocode_lines, pseudocode_hash1, pseudocode_primes, "
+            "function_flags, assembly, prototype2, pseudocode_hash2, "
+            "pseudocode_hash3, strongly_connected, loops, rva, "
+            "tarjan_topological_sort, strongly_connected_spp, "
+            "clean_assembly, clean_pseudo, mnemonics_spp, switches, "
+            "function_hash, bytes_sum, md_index, constants, "
+            "constants_count, segment_rva, assembly_addrs, kgh_hash, "
+            "source_file, userdata, microcode, clean_microcode, "
+            "microcode_spp"
+        )
+        column_defaults = (
+            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+            "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?"
+        )
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def callgraph(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+    ) -> None:
+        table = "callgraph"
+        column_names = "func_id, address, type"
+        column_defaults = "?, ?, ?"
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def constants(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+    ) -> None:
+        table = "constants"
+        column_names = "func_id, constant"
+        column_defaults = "?, ?"
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)
+
+    def __template(
+        self,
+        cur_execute: Callable[[str, List[Any]], None],
+        properties: List[Any],
+        obj_type: str = NATIVE,
+    ) -> None:
+        table = ""
+        if obj_type == NATIVE:
+            column_names = ""
+            column_defaults = ""
+        elif obj_type == MICROCODE:
+            column_names = ""
+            column_defaults = ""
+        else:
+            raise ValueError(f"Unknown type '{obj_type}'")
+        self.__execute(cur_execute, table, column_names, column_defaults, properties)


### PR DESCRIPTION
Following our brief exchange on mastodon, here is a complete parallel export code, with functions and call graph.

With 5 workers I get a 2x speedup on  a 1MB binary and 100% match on callgraph and functions from a regular export.

- Each job is assigned some of the functions to export.
- all resulting db are merged
- a final job exports the remaining data

I refactored all SQL insertions related to functions in order to easily switch between:
- sequential export: rows are inserted sequentially
- parallel export: ensure `rowid % nbr_jobs = job_id` in order to avoid collisions when merging

run with: `IDADIR=<path-to-ida> ./diaphora_parallel_export.py <path-to-target-binary>`

Two potential improvements that remain to be done:
- [x] distribute address ranges to workers without relaunching IDA (needs a communication channel with the ida scripts)
- [ ] use a threadsafe db in order to parallelize merges

Sequential export still seems to work.