### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/pygments/lexers/mcfunction.py
+++ b/pygments/lexers/mcfunction.py
@@ -24,7 +24,7 @@ class SNBTLexer(RegexLexer):
     """
 
     name = "SNBT"
-    url = "https://minecraft.fandom.com/wiki/NBT_format"
+    url = "https://minecraft.wiki/w/NBT_format"
     aliases = ["snbt"]
     filenames = ["*.snbt"]
     mimetypes = ["text/snbt"]
@@ -98,7 +98,7 @@ class MCFunctionLexer(RegexLexer):
     """
 
     name = "MCFunction"
-    url = "https://minecraft.fandom.com/wiki/Commands"
+    url = "https://minecraft.wiki/w/Commands"
     aliases = ["mcfunction", "mcf"]
     filenames = ["*.mcfunction"]
     mimetypes = ["text/mcfunction"]


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the previous fandom wiki link accordingly.