### PR TITLE
Fix: callees inserted as callers

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -1096,7 +1096,7 @@ class CBinDiff:
         insert_args.append([func_id, str(caller), "caller"])
 
       for callee in callees:
-        insert_args.append([func_id, str(callee), "caller"])      
+        insert_args.append([func_id, str(callee), "callee"])      
       cur.executemany(sql, insert_args)
 
       # Phase 3: Insert the constants of the function


### PR DESCRIPTION
Bug introduced in c69f3922498087d299352e5facab67667673d128:
```diff
diff --git a/diaphora.py b/diaphora.py
index 988af6a..59a5ff7 100755
--- a/diaphora.py
+++ b/diaphora.py
@@ -1078,14 +1091,17 @@ class CBinDiff:
       # Phase 2: Save the callers and callees of the function
       callers, callees = props[len(props) - 4:len(props) - 2]
       sql = "insert into callgraph (func_id, address, type) values (?, ?, ?)"
+      insert_args = []
       for caller in callers:
-        cur.execute(sql, (func_id, str(caller), "caller"))
+        insert_args.append([func_id, str(caller), "caller"])
 
       for callee in callees:
-        cur.execute(sql, (func_id, str(callee), "callee"))               # <-- callee
+        insert_args.append([func_id, str(callee), "caller"])             # <-- caller
+      cur.executemany(sql, insert_args)
 
       # Phase 3: Insert the constants of the function
       sql = "insert into constants (func_id, constant) values (?, ?)"
+      insert_args = []
       props_dict = self.create_function_dictionary(props)
       for constant in props_dict["constants"]:
         should_add = False
```