### PR TITLE
Replace `imp` module (removed in Python 3.12; to fix compatibility with IDA 8.4)

### DIFF
--- a/codecut/cc_main.py
+++ b/codecut/cc_main.py
@@ -22,7 +22,7 @@ import module
 import cc_base
 import basicutils_7x as basicutils
 import snap_cg
-import imp
+import importlib
 
 try:
   import modnaming
@@ -57,12 +57,12 @@ def go():
 	return True
 
 if __name__ == "__main__":
-	imp.reload(modnaming)
-	imp.reload(module)
-	imp.reload(cc_base)
-	imp.reload(lfa)
-	imp.reload(maxcut)
-	imp.reload(snap_cg)
-	imp.reload(basicutils)
+	importlib.reload(modnaming)
+	importlib.reload(module)
+	importlib.reload(cc_base)
+	importlib.reload(lfa)
+	importlib.reload(maxcut)
+	importlib.reload(snap_cg)
+	importlib.reload(basicutils)
 	go()
 


### PR DESCRIPTION
This is a small fix to make Diaphora work with IDA 8.4, which uses Python 3.12. Without it, loading `diaphora.py` throws an error:

```
diaphora.py: No module named 'imp'
Traceback (most recent call last):
  File "<snip>\IDA Pro 8.4\python\3\ida_idaapi.py", line 576, in IDAPython_ExecScript
    exec(code, g)
  File "<snip>/diaphora/diaphora.py", line 24, in <module>
    import imp
ModuleNotFoundError: No module named 'imp'
```

See also https://docs.python.org/3.12/whatsnew/3.12.html#imp for the notes about the `imp` module removal.

And two questions:
- How to test `cc_main.py`? It seems unused currently.
- `cc_main.py` has CRLF newlines, so I made my changes also with CRLF there.