### PR TITLE
Fix IDA deadlock when time reaches `SQL_TIMEOUT_LIMIT`

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -2049,7 +2049,7 @@ class CBinDiff:
     t = time.monotonic()
     while self.continue_getting_sql_rows(i):
       if time.monotonic() - t > self.timeout or cur_thread.timeout:
-        log_refresh(f"Timeout with heuristic '{cur_thread.name}'")
+        log(f"Timeout with heuristic '{cur_thread.name}'")
         raise SystemExit()
 
       i += 1


### PR DESCRIPTION
IDA will deadlock when performing heuristics and time reaches `SQL_TIMEOUT_LIMIT`

Environment: IDA 9.0 @ Windows 11

The bug seems to be introduced here: https://github.com/joxeankoret/diaphora/commit/2c97b4f8d48bcee33a6e8c08849b752ea99a7271#diff-e2daac30fa9a0b3aca61030ec1fe8038281999c3ef09d2082d967c700ece5ffcR2043