### PR TITLE
add IDA version >= 9.2 compatilibity for Qt6

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -70,7 +70,10 @@ except ImportError:
   HAS_GET_SOURCE_STRINGS = False
 
 # pylint: disable-next=wrong-import-order
-from PyQt5 import QtWidgets
+if IDA_SDK_VERSION < 920:
+  from PyQt5 import QtWidgets
+else:
+  from PySide6 import QtWidgets
 
 #-------------------------------------------------------------------------------
 # Chooser items indices. They do differ from the CChooser.item items that are

--- a/extras/diaphora_local.py
+++ b/extras/diaphora_local.py
@@ -28,7 +28,10 @@ import idc
 import idaapi
 import idautils
 
-from PyQt5 import QtWidgets
+if idaapi.IDA_SDK_VERSION < 920:
+  from PyQt5 import QtWidgets
+else:
+  from PySide6 import QtWidgets
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import NasmLexer, CppLexer, DiffLexer

--- a/jkutils/IDAMagicStrings.py
+++ b/jkutils/IDAMagicStrings.py
@@ -23,7 +23,10 @@ from idaapi import *
 from idautils import *
 
 try:
-  from PyQt5 import QtWidgets
+  if IDA_SDK_VERSION < 920:
+    from PyQt5 import QtWidgets
+  else:
+    from PySide6 import QtWidgets
 except ImportError as e:
   print(f'{os.path.basename(__file__)} importerror {e}')
 


### PR DESCRIPTION
The Qt5 has been deprecated since IDA version 9.2.
- ref: https://docs.hex-rays.com/release-notes/9_2#qt6

add compatibility for QtWidgets import.