### PR TITLE
Support IDA Pro 9.2+ (PySide6) and headless idalib usage

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -35,7 +35,6 @@ from idaapi import *
 from idautils import *
 # pylint: enable=unused-wildcard-import
 # pylint: enable=wildcard-import
-
 import ida_pro
 import idaapi
 
@@ -71,10 +70,14 @@ except ImportError:
   HAS_GET_SOURCE_STRINGS = False
 
 # pylint: disable-next=wrong-import-order
-if ida_pro.IDA_SDK_VERSION >= 920:
-  from PySide6 import QtWidgets
-else:
-  from PyQt5 import QtWidgets
+# Guard Qt imports for headless idalib mode (no GUI available)
+try:
+  if ida_pro.IDA_SDK_VERSION >= 920:
+    from PySide6 import QtWidgets
+  else:
+    from PyQt5 import QtWidgets
+except ImportError:
+  QtWidgets = None
 
 #-------------------------------------------------------------------------------
 # Chooser items indices. They do differ from the CChooser.item items that are

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -36,6 +36,7 @@ from idautils import *
 # pylint: enable=unused-wildcard-import
 # pylint: enable=wildcard-import
 
+import ida_pro
 import idaapi
 
 idaapi.require("diaphora")
@@ -70,7 +71,10 @@ except ImportError:
   HAS_GET_SOURCE_STRINGS = False
 
 # pylint: disable-next=wrong-import-order
-from PyQt5 import QtWidgets
+if ida_pro.IDA_SDK_VERSION >= 920:
+  from PySide6 import QtWidgets
+else:
+  from PyQt5 import QtWidgets
 
 #-------------------------------------------------------------------------------
 # Chooser items indices. They do differ from the CChooser.item items that are

--- a/extras/diaphora_local.py
+++ b/extras/diaphora_local.py
@@ -27,8 +27,13 @@ import difflib
 import idc
 import idaapi
 import idautils
+import ida_pro
 
-from PyQt5 import QtWidgets
+if ida_pro.IDA_SDK_VERSION >= 920:
+  from PySide6 import QtWidgets
+else:
+  from PyQt5 import QtWidgets
+
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 from pygments.lexers import NasmLexer, CppLexer, DiffLexer

--- a/jkutils/IDAMagicStrings.py
+++ b/jkutils/IDAMagicStrings.py
@@ -17,13 +17,17 @@ import re
 from collections import Counter
 
 import idaapi
+import ida_pro
 
 from idc import *
 from idaapi import *
 from idautils import *
 
 try:
-  from PyQt5 import QtWidgets
+  if ida_pro.IDA_SDK_VERSION >= 920:
+    from PySide6 import QtWidgets
+  else:
+    from PyQt5 import QtWidgets
 except ImportError as e:
   print(f'{os.path.basename(__file__)} importerror {e}')
 


### PR DESCRIPTION
 ## Summary
  - Add IDA Pro 9.2+ compatibility by switching Qt bindings from PyQt5 to PySide6 when `IDA_SDK_VERSION >= 920`, while preserving the PyQt5 path on older versions.
  - Allow `diaphora_ida` to be imported in headless `idalib` contexts where Qt is unavailable: the Qt import is now guarded and `QtWidgets` falls back to `None` on `ImportError`.

 ## Credits
The IDA 9.2+ support was contributed by **@GaoYuCan** — see https://github.com/GaoYuCan/diaphora