### PR TITLE
Fix slow basic block export and resume handling

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -557,7 +557,9 @@ class CBinDiff:
     """
     value = os.getenv(f"DIAPHORA_{value_name.upper()}")
     if value is not None:
-      if isinstance(value, type(default)):
+      if isinstance(default, bool):
+        value = value.lower() in ("1", "true", "yes", "on")
+      elif default is not None and not isinstance(default, str):
         value = type(default)(value)
       return value
     return default
@@ -692,24 +694,6 @@ class CBinDiff:
     finally:
       cur.close()
 
-  def get_bb_id(self, addr):
-    """
-    Get the id of the given basic block at address @addr
-    """
-    cur = self.db_cursor()
-    rowid = None
-    try:
-      sql = "select id from basic_blocks where address = ?"
-      cur.execute(sql, (str(addr),))
-      row = cur.fetchone()
-      rowid = None
-      if row is not None:
-        rowid = row["id"]
-    finally:
-      cur.close()
-
-    return rowid
-
   def get_valid_prop(self, prop):
     """
     Get a valid property to insert into the SQLite database.
@@ -778,15 +762,12 @@ class CBinDiff:
     sql1 = "insert into main.basic_blocks (num, address, asm_type) values (?, ?, 'native')"
     sql2 = "insert into main.bb_instructions (basic_block_id, instruction_id) values (?, ?)"
 
-    self_get_bb_id = self.get_bb_id
     for key in bb_data:
       # Insert each basic block
       num += 1
       ins_ea = str(key)
-      last_bb_id = self_get_bb_id(ins_ea)
-      if last_bb_id is None:
-        cur_execute(sql1, (num, str(ins_ea)))
-        last_bb_id = cur.lastrowid
+      cur_execute(sql1, (num, str(ins_ea)))
+      last_bb_id = cur.lastrowid
       bb_ids[ins_ea] = last_bb_id
 
       # Insert relations between basic blocks and instructions

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -1137,6 +1137,9 @@ class CIDABinDiff(diaphora.CBinDiff):
     func_list = list(Functions(self.min_ea, self.max_ea))
     total_funcs = len(func_list)
     t = time.monotonic()
+    last_progress_update = 0
+    progress_update_interval = 60
+    progress_step = int(total_funcs / 100) if total_funcs >= 100 else 1
 
     if crashed_before:
       start_func = self.get_last_crash_func()
@@ -1157,11 +1160,15 @@ class CIDABinDiff(diaphora.CBinDiff):
         raise Exception("Cancelled.")
 
       i += 1
-      if (total_funcs >= 100) and i % (int(total_funcs / 100)) == 0 or i == 1:
+      now = time.monotonic()
+      update_by_count = i % progress_step == 0
+      update_by_time = now - last_progress_update >= progress_update_interval
+      if i == 1 or update_by_count or update_by_time:
+        last_progress_update = now
         if config.COMMIT_AFTER_EACH_GUI_UPDATE:
           self.commit_and_start_transaction()
         line = "Exported %d function(s) out of %d total.\nElapsed %d:%02d:%02d second(s), remaining time ~%d:%02d:%02d"
-        elapsed = time.monotonic() - t
+        elapsed = now - t
         remaining = (elapsed / i) * (total_funcs - i)
 
         m, s = divmod(remaining, 60)
@@ -1218,6 +1225,22 @@ class CIDABinDiff(diaphora.CBinDiff):
 
     log_refresh("Creating indices...")
     self.create_indices()
+    return True
+
+  def check_export_database_integrity(self):
+    """
+    Verify that a database from a crashed export can still be read by SQLite.
+    """
+    cur = self.db_cursor()
+    try:
+      cur.execute("pragma integrity_check")
+      row = cur.fetchone()
+      if row is None or row[0].lower() != "ok":
+        raise sqlite3.DatabaseError(
+          f"database integrity check failed: {row[0] if row else 'no result'}"
+        )
+    finally:
+      cur.close()
 
   def export(self):
     """
@@ -1237,10 +1260,13 @@ class CIDABinDiff(diaphora.CBinDiff):
     with open(crash_file, "wb") as f:
       f.close()
 
+    exported = False
     try:
       show_wait_box("Exporting database")
       try:
-        self.do_export(crashed_before)
+        if crashed_before:
+          self.check_export_database_integrity()
+        exported = self.do_export(crashed_before)
       except:
         log(f"Error: {str(sys.exc_info()[1])}")
         traceback.print_exc()
@@ -1251,6 +1277,10 @@ class CIDABinDiff(diaphora.CBinDiff):
               raise
     finally:
       hide_wait_box()
+
+    if not exported:
+      self.db_close()
+      return False
 
     self.db.commit()
     log(f"Removing crash file {self.db_name}-crash...")
@@ -1263,6 +1293,7 @@ class CIDABinDiff(diaphora.CBinDiff):
       cur.close()
 
     self.db_close()
+    return True
 
   def import_til(self):
     """
@@ -2276,8 +2307,6 @@ class CIDABinDiff(diaphora.CBinDiff):
       else:
         self.pseudo[ea].append(line)
 
-    self.microcode[ea] = []
-    self.get_microcode(f, ea)
     return first_line
 
   def guess_type(self, ea):
@@ -2920,8 +2949,8 @@ or selecting Edit -> Plugins -> Diaphora - Show results"""
     ) = self.extract_function_pseudocode_features(f)
 
     # Extract microcode
-    microcode, clean_microcode, microcode_spp = self.extract_microcode(f)
     microcode_bblocks, microcode_bbrelations = self.get_microcode(func, ea)
+    microcode, clean_microcode, microcode_spp = self.extract_microcode(f)
 
     clean_pseudo = self.get_cmp_pseudo_lines(pseudo)
 
@@ -3957,12 +3986,15 @@ def main():
 
     auto_wait()
 
-    if os.path.exists(file_out):
+    crash_file = f"{file_out}-crash"
+    if os.path.exists(file_out) and not os.path.exists(crash_file):
       if g_bindiff is not None:
         g_bindiff = None
 
       remove_file(file_out)
       log(f"Database {repr(file_out)} removed")
+    elif os.path.exists(file_out):
+      log(f"Keeping database {repr(file_out)} to resume interrupted export")
 
     bd = CIDABinDiff(file_out)
     project_script = os.getenv("DIAPHORA_PROJECT_SCRIPT")
@@ -3980,7 +4012,7 @@ def main():
     )
     bd.min_ea = int(bd.get_value_for("from_address", "0"), 16)
     bd.export_microcode = bd.get_value_for(
-      "self.export_microcode", bd.export_microcode
+      "export_microcode", bd.export_microcode
     )
 
     _to_ea = bd.get_value_for("to_address", None)


### PR DESCRIPTION
## Summary

This PR fixes #305 and several related export-time and crash-resume issues found while investigating very large Diaphora exports.

The work was completed jointly by Raincarnator and Codex.

## Changes

### 1. Remove the per-basic-block `get_bb_id()` query

`insert_basic_blocks_to_database()` used to resolve every basic block id by querying `basic_blocks` with its address before inserting the `bb_instructions` relation.

The historical behavior appears to have made sense in older schema versions, where a basic block address uniquely identified a row in `basic_blocks`. In Diaphora 2.1.0, for example, the table was effectively modeled like this:

```sql
basic_blocks (
  id integer primary key,
  num integer,
  address text unique
)
```

With that schema, `get_bb_id(address)` was a reasonable safeguard: if a basic block row for that address had already been inserted, the exporter could reuse it; if not, it inserted a new row. Because `address` was unique, the lookup had unambiguous semantics, and because the column was unique/indexed, the lookup was cheap.

That assumption no longer holds in the current schema. `basic_blocks` now also stores `asm_type`:

```sql
basic_blocks (
  id integer primary key,
  num integer,
  address text,
  asm_type text
)
```

The same address can now legitimately appear more than once, for example once as native basic block data and once as microcode basic block data. The address uniqueness assumption is therefore gone, and the old address lookup is no longer a reliable global identity lookup. More importantly, the current `get_bb_id()` query only filters by `address`:

```sql
select id from basic_blocks where address = ?
```

It does not filter by `asm_type`, and it does not restrict the row to the current function. In the current schema, such a query may return a row from another representation, or another context that happens to share the same address. So the old logic is not only expensive on large exports after the address uniqueness/index assumption disappeared; it is also less precise than using the row that was just inserted.

For the native basic-block export path fixed here, re-querying by address is not necessary. The exporter is already executing this sequence locally:

1. insert one native row into `basic_blocks`;
2. read the inserted row id;
3. insert `bb_instructions`, `bb_relations`, and `function_bblocks` rows that should point to that newly inserted native basic block.

In this sequence, `cursor.lastrowid` is exactly the id that the exporter needs. It identifies the row inserted by the immediately preceding `insert into basic_blocks` statement on the same cursor. Re-querying by address is therefore not adding correctness for this relation; it tries to rediscover the same local row through a slower and now ambiguous key.

This does mean that `basic_blocks` may contain multiple rows with the same address. In the current schema that is already allowed and expected, because `asm_type` makes address alone insufficient as a row identity. The exported graph queries already go through `function_bblocks` and `basic_block_id`, and also filter by `asm_type`, so each function should use the specific basic block rows linked to it rather than a globally shared row found by address alone.

Experiment result:
- on the provided small sample, this change reduced the native basic-block insertion hot path from repeatedly querying `basic_blocks` by address to directly using the inserted row id;
- this specifically removes the per-basic-block SQLite lookup identified as the main source of the #305 export-time regression;
- adding an index to the address lookup alone was not enough to resolve the slowdown reported in #305, because the exporter still performed the extra lookup for every basic block.

Expected effect:
- removes one hot-loop SQLite query per native basic block;
- avoids depending on an address lookup that is no longer uniquely identifying;
- preserves the intended relation between the newly inserted basic block and its instructions;
- improves export speed for binaries with many basic blocks.

### 2. Fix typed `DIAPHORA_*` option parsing

`get_value_for()` previously checked `isinstance(value, type(default))`, but environment variables are strings. This meant bool/int-like settings were not reliably converted.

This was especially problematic for boolean values. For example, an environment value such as `"0"` was still a non-empty string, so code paths that treated it as a boolean could behave as enabled instead of disabled.

This PR:
- parses boolean defaults explicitly (`1/true/yes/on` become true; values such as `0/false/no/off` do not);
- converts non-string defaults such as integers using the default’s type.

Expected effect:
- automated export options now match the requested configuration;
- `DIAPHORA_EXPORT_MICROCODE=0` can correctly disable microcode.

### 3. Fix automatic export microcode option name

Automatic export read `"self.export_microcode"` instead of `"export_microcode"`, so `DIAPHORA_EXPORT_MICROCODE` was ignored.

Expected effect:
- automatic exports now honor the microcode option;
- disabling microcode reduces unexpected export work and DB size.

Experiment result:
- on the provided small sample, fixing this option reduced the decompiler + summary-only + microcode-off output from the microcode-on-sized DB to about 76.5MB instead of about 138MB.

### 4. Avoid duplicate microcode generation

Microcode was generated once inside `decompile_and_get()` and then again in `extract_all_features()`.

This PR removes the earlier generation and keeps the later one, so microcode is produced once and then immediately consumed by `extract_microcode()`.

Expected effect:
- avoids duplicated Hex-Rays microcode generation;
- keeps the exported microcode data and schema unchanged.

Experiment result:
- on the provided small sample with microcode enabled, export time improved from about 213s to about 182s;
- output DB size stayed in the expected range because the same microcode data is still exported, just not generated twice.

### 5. Make crash resume safer

`do_export()` now returns success explicitly, and `export()` only finalizes the DB after a successful export.

Expected effect:
- failed exports keep the crash marker;
- incomplete exports are not finalized as successful ones.

### 6. Preserve crashed export DBs in automatic mode

Automatic export now keeps an existing output DB when the matching `output.sqlite-crash` marker exists.

Expected effect:
- automatic exports can resume from the existing partial DB instead of deleting it first.

### 7. Improve progress dialog refresh cadence

The progress dialog still updates by percentage, but now also refreshes about once every 60 seconds.

Expected effect:
- long exports show visible progress more regularly;
- export data and DB output are unchanged.

## Verification

- `python -m py_compile diaphora.py diaphora_ida.py`
- `git diff --check -- diaphora.py diaphora_ida.py`
- Small-sample automatic export experiments confirmed:
  - microcode-off is now honored;
  - duplicate microcode generation is removed;
  - microcode-enabled export time improved from about 213s to about 182s in the measured run.