### PR TITLE
Speed up compilation unit export and fix related CU range matching

### DIFF
--- a/diaphora.py
+++ b/diaphora.py
@@ -557,7 +557,9 @@ class CBinDiff:
     """
     value = os.getenv(f"DIAPHORA_{value_name.upper()}")
     if value is not None:
-      if isinstance(value, type(default)):
+      if isinstance(default, bool):
+        value = value.lower() in ("1", "true", "yes", "on")
+      elif default is not None and not isinstance(default, str):
         value = type(default)(value)
       return value
     return default
@@ -692,24 +694,6 @@ class CBinDiff:
     finally:
       cur.close()
 
-  def get_bb_id(self, addr):
-    """
-    Get the id of the given basic block at address @addr
-    """
-    cur = self.db_cursor()
-    rowid = None
-    try:
-      sql = "select id from basic_blocks where address = ?"
-      cur.execute(sql, (str(addr),))
-      row = cur.fetchone()
-      rowid = None
-      if row is not None:
-        rowid = row["id"]
-    finally:
-      cur.close()
-
-    return rowid
-
   def get_valid_prop(self, prop):
     """
     Get a valid property to insert into the SQLite database.
@@ -778,15 +762,12 @@ class CBinDiff:
     sql1 = "insert into main.basic_blocks (num, address, asm_type) values (?, ?, 'native')"
     sql2 = "insert into main.bb_instructions (basic_block_id, instruction_id) values (?, ?)"
 
-    self_get_bb_id = self.get_bb_id
     for key in bb_data:
       # Insert each basic block
       num += 1
       ins_ea = str(key)
-      last_bb_id = self_get_bb_id(ins_ea)
-      if last_bb_id is None:
-        cur_execute(sql1, (num, str(ins_ea)))
-        last_bb_id = cur.lastrowid
+      cur_execute(sql1, (num, str(ins_ea)))
+      last_bb_id = cur.lastrowid
       bb_ids[ins_ea] = last_bb_id
 
       # Insert relations between basic blocks and instructions

--- a/diaphora.py
+++ b/diaphora.py
@@ -3428,9 +3428,9 @@ class CBinDiff:
           continue
 
         main_start_ea = float(main_row["start_ea"])
-        main_end_ea   = float(main_row["start_ea"])
+        main_end_ea   = float(main_row["end_ea"])
         diff_start_ea = float(diff_row["start_ea"])
-        diff_end_ea   = float(diff_row["start_ea"])
+        diff_end_ea   = float(diff_row["end_ea"])
         cur.execute(sql, (main_start_ea, main_end_ea, diff_start_ea, diff_end_ea))
         self.add_matches_internal(cur, "best", "partial")
     finally:

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -1137,6 +1137,9 @@ class CIDABinDiff(diaphora.CBinDiff):
     func_list = list(Functions(self.min_ea, self.max_ea))
     total_funcs = len(func_list)
     t = time.monotonic()
+    last_progress_update = 0
+    progress_update_interval = 60
+    progress_step = int(total_funcs / 100) if total_funcs >= 100 else 1
 
     if crashed_before:
       start_func = self.get_last_crash_func()
@@ -1157,11 +1160,15 @@ class CIDABinDiff(diaphora.CBinDiff):
         raise Exception("Cancelled.")
 
       i += 1
-      if (total_funcs >= 100) and i % (int(total_funcs / 100)) == 0 or i == 1:
+      now = time.monotonic()
+      update_by_count = i % progress_step == 0
+      update_by_time = now - last_progress_update >= progress_update_interval
+      if i == 1 or update_by_count or update_by_time:
+        last_progress_update = now
         if config.COMMIT_AFTER_EACH_GUI_UPDATE:
           self.commit_and_start_transaction()
         line = "Exported %d function(s) out of %d total.\nElapsed %d:%02d:%02d second(s), remaining time ~%d:%02d:%02d"
-        elapsed = time.monotonic() - t
+        elapsed = now - t
         remaining = (elapsed / i) * (total_funcs - i)
 
         m, s = divmod(remaining, 60)
@@ -1218,6 +1225,22 @@ class CIDABinDiff(diaphora.CBinDiff):
 
     log_refresh("Creating indices...")
     self.create_indices()
+    return True
+
+  def check_export_database_integrity(self):
+    """
+    Verify that a database from a crashed export can still be read by SQLite.
+    """
+    cur = self.db_cursor()
+    try:
+      cur.execute("pragma integrity_check")
+      row = cur.fetchone()
+      if row is None or row[0].lower() != "ok":
+        raise sqlite3.DatabaseError(
+          f"database integrity check failed: {row[0] if row else 'no result'}"
+        )
+    finally:
+      cur.close()
 
   def export(self):
     """
@@ -1237,10 +1260,13 @@ class CIDABinDiff(diaphora.CBinDiff):
     with open(crash_file, "wb") as f:
       f.close()
 
+    exported = False
     try:
       show_wait_box("Exporting database")
       try:
-        self.do_export(crashed_before)
+        if crashed_before:
+          self.check_export_database_integrity()
+        exported = self.do_export(crashed_before)
       except:
         log(f"Error: {str(sys.exc_info()[1])}")
         traceback.print_exc()
@@ -1251,6 +1277,10 @@ class CIDABinDiff(diaphora.CBinDiff):
               raise
     finally:
       hide_wait_box()
+
+    if not exported:
+      self.db_close()
+      return False
 
     self.db.commit()
     log(f"Removing crash file {self.db_name}-crash...")
@@ -1263,6 +1293,7 @@ class CIDABinDiff(diaphora.CBinDiff):
       cur.close()
 
     self.db_close()
+    return True
 
   def import_til(self):
     """
@@ -2276,8 +2307,6 @@ class CIDABinDiff(diaphora.CBinDiff):
       else:
         self.pseudo[ea].append(line)
 
-    self.microcode[ea] = []
-    self.get_microcode(f, ea)
     return first_line
 
   def guess_type(self, ea):
@@ -2920,8 +2949,8 @@ or selecting Edit -> Plugins -> Diaphora - Show results"""
     ) = self.extract_function_pseudocode_features(f)
 
     # Extract microcode
-    microcode, clean_microcode, microcode_spp = self.extract_microcode(f)
     microcode_bblocks, microcode_bbrelations = self.get_microcode(func, ea)
+    microcode, clean_microcode, microcode_spp = self.extract_microcode(f)
 
     clean_pseudo = self.get_cmp_pseudo_lines(pseudo)
 
@@ -3957,12 +3986,15 @@ def main():
 
     auto_wait()
 
-    if os.path.exists(file_out):
+    crash_file = f"{file_out}-crash"
+    if os.path.exists(file_out) and not os.path.exists(crash_file):
       if g_bindiff is not None:
         g_bindiff = None
 
       remove_file(file_out)
       log(f"Database {repr(file_out)} removed")
+    elif os.path.exists(file_out):
+      log(f"Keeping database {repr(file_out)} to resume interrupted export")
 
     bd = CIDABinDiff(file_out)
     project_script = os.getenv("DIAPHORA_PROJECT_SCRIPT")
@@ -3980,7 +4012,7 @@ def main():
     )
     bd.min_ea = int(bd.get_value_for("from_address", "0"), 16)
     bd.export_microcode = bd.get_value_for(
-      "self.export_microcode", bd.export_microcode
+      "export_microcode", bd.export_microcode
     )
 
     _to_ea = bd.get_value_for("to_address", None)

--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -26,6 +26,7 @@ import sqlite3
 import datetime
 import traceback
 
+from bisect import bisect_left, bisect_right
 from hashlib import md5
 
 from idc import *
@@ -3204,9 +3205,59 @@ or selecting Edit -> Plugins -> Diaphora - Show results"""
   def get_base_address(self):
     return idaapi.get_imagebase()
 
+  def get_sorted_cached_functions(self):
+    funcs = []
+    for func, item in self._funcs_cache.items():
+      funcs.append((int(func), item))
+    funcs.sort(key=lambda item: item[0])
+    return funcs
+
+  def iter_cached_functions_in_range(self, funcs, keys, start, end):
+    first = bisect_left(keys, start)
+    last = bisect_right(keys, end)
+    for _, item in funcs[first:last]:
+      yield item
+
+  def get_lfa_module_ranges(self, lfa_modules):
+    module_ranges = []
+    for index, module in enumerate(lfa_modules):
+      module_ranges.append((module.start, module.end, index, module))
+    module_ranges.sort(key=lambda item: item[0])
+
+    keys = [start for start, _, _, _ in module_ranges]
+    max_ends = []
+    max_end = 0
+    for _, end, _, _ in module_ranges:
+      max_end = max(max_end, end)
+      max_ends.append(max_end)
+    return module_ranges, keys, max_ends
+
+  def find_lfa_module_for_ea(self, module_ranges, keys, max_ends, ea):
+    pos = bisect_right(keys, ea) - 1
+    best_index = None
+    best_module = None
+    while pos >= 0:
+      if max_ends[pos] < ea:
+        break
+
+      start, end, index, module = module_ranges[pos]
+      if start <= ea <= end:
+        if best_index is None or index < best_index:
+          best_index = index
+          best_module = module
+      pos -= 1
+    return best_module
+
   def get_modules_using_lfa(self):
     # First, try to guess modules areas
     _, lfa_modules = lfa.analyze()
+    module_ranges, module_keys, module_max_ends = self.get_lfa_module_ranges(
+      lfa_modules
+    )
+    new_modules = [
+      {"name": module.name, "start": module.start, "end": module.end}
+      for module in lfa_modules
+    ]
 
     # Next, using IDAMagicStrings, try to guess file names using some heuristics
     func_modules = {}
@@ -3221,11 +3272,11 @@ or selecting Edit -> Plugins -> Diaphora - Show results"""
           if func_ea not in func_modules:
             # print("0x%08x:%s -> %s" % (func_ea, func_name, mod_name))
             func_modules[func_ea] = mod_name
-            for module in lfa_modules:
-              if func_ea >= module.start and func_ea <= module.end:
-                if module.name == "":
-                  module.name = mod_name
-                  break
+            module = self.find_lfa_module_for_ea(
+              module_ranges, module_keys, module_max_ends, func_ea
+            )
+            if module is not None and module.name == "":
+              module.name = mod_name
 
       #
       # Next sub-step: find the limits of modules with the same name that appear
@@ -3274,20 +3325,25 @@ or selecting Edit -> Plugins -> Diaphora - Show results"""
       module["primes"] = 1
       module["pseudo_primes"] = 1
 
-    iterations = 1
-    for func, item in self._funcs_cache.items():
-      if iterations % 1000 == 0:
+    funcs = self.get_sorted_cached_functions()
+    func_keys = [func for func, _ in funcs]
+    assigned_funcs = set()
+    for i, module in enumerate(new_modules):
+      if i > 0 and i % 1000 == 0:
         log_refresh("Calculating modules weights...")
 
-      for module in new_modules:
-        if module["start"] <= func <= module["end"]:
-          _, primes_value, pseudocode_primes = item
-          module["total"] += 1
-          if primes_value is not None:
-            module["primes"] *= int(primes_value)
-          if pseudocode_primes is not None:
-            module["pseudo_primes"] *= int(pseudocode_primes)
-          break
+      for item in self.iter_cached_functions_in_range(
+        funcs, func_keys, module["start"], module["end"]
+      ):
+        func_id, primes_value, pseudocode_primes = item
+        if func_id in assigned_funcs:
+          continue
+        assigned_funcs.add(func_id)
+        module["total"] += 1
+        if primes_value is not None:
+          module["primes"] *= int(primes_value)
+        if pseudocode_primes is not None:
+          module["pseudo_primes"] *= int(pseudocode_primes)
 
     for module in new_modules:
       module["total"] = str(module["total"])
@@ -3319,6 +3375,8 @@ or selecting Edit -> Plugins -> Diaphora - Show results"""
       dones = set()
       total = len(lfa_modules)
       checkpoint = int(total / 100)
+      funcs = self.get_sorted_cached_functions()
+      func_keys = [func for func, _ in funcs]
       for i, module in enumerate(lfa_modules):
         if i > 0 and checkpoint > 0 and i % checkpoint == 0:
           log_refresh(f"Processing compilation unit {i} out of {total}...")
@@ -3331,15 +3389,18 @@ or selecting Edit -> Plugins -> Diaphora - Show results"""
         cur.execute(sql1, vals)
         cu_id = cur.lastrowid
 
-        for func in self._funcs_cache:
-          item = self._funcs_cache[func]
-          func = int(func)
-          if func >= module["start"] and func <= module["end"]:
-            func_id = item[0]
-            if func_id not in dones:
-              dones.add(func_id)
-              cur.execute(sql2, (cu_id, func_id))
-              cur.execute(sql4, (module_name, func_id))
+        cu_func_args = []
+        source_file_args = []
+        for item in self.iter_cached_functions_in_range(
+          funcs, func_keys, module["start"], module["end"]
+        ):
+          func_id = item[0]
+          if func_id not in dones:
+            dones.add(func_id)
+            cu_func_args.append((cu_id, func_id))
+            source_file_args.append((module_name, func_id))
+        cur.executemany(sql2, cu_func_args)
+        cur.executemany(sql4, source_file_args)
 
         cur.execute(
           sql3,


### PR DESCRIPTION
## Summary

This PR improves compilation unit handling in two places:

1. Speeds up compilation unit export.
2. Fixes the address range used by the related compilation unit diff heuristic.

## Changes

### Speed up compilation unit export

The exporter previously matched functions to LFA compilation-unit ranges by repeatedly scanning all cached functions for each module. On large databases this becomes very expensive, e.g. thousands of modules times hundreds of thousands of functions.

This PR builds sorted function-address arrays and uses binary search to find the functions inside each module range. It also batches the `compilation_unit_functions` and `source_file` updates with `executemany()`.

The source-string-to-module lookup was also changed to use sorted LFA module ranges instead of linearly scanning every module for each source-string function.

This keeps the exported compilation unit data equivalent, but avoids the large nested scans.

### Fix related compilation unit range matching

`find_related_compilation_unit()` selected both `start_ea` and `end_ea`, but assigned the end variables from `start_ea`:

```python
main_end_ea = main_row["start_ea"]
diff_end_ea = diff_row["start_ea"]
```

That made the later `between start and end` query only cover the start address, so the heuristic was effectively restricted to a single address instead of the compilation unit range.

This PR changes those assignments to use `end_ea`, matching the selected columns and the intended range-based heuristic.

## Verification

- Ran `python -m py_compile diaphora.py diaphora_ida.py`.