### PR TITLE
Fix diff viewer readability in IDA Dark mode

### DIFF
--- a/diaphora_ida.py
+++ b/diaphora_ida.py
@@ -3864,22 +3864,26 @@ class CHtmlDiff:
   background-color: """
     + config.DIFF_COLOR_ADDED
     + """;
+  color: #000000;
   }
   .diff_chg {
   background-color: """
     + config.DIFF_COLOR_CHANGED
     + """;
+  color: #000000;
   }
   .diff_sub {
   background-color: """
     + config.DIFF_COLOR_SUBTRACTED
     + """;
+  color: #000000;
   }
   .diff_lineno {
   text-align: right;
   background-color: """
     + config.DIFF_COLOR_LINE_NO
     + """;
+  color: #888888;
   }
   """
   )


### PR DESCRIPTION
# Fix diff viewer readability in IDA Dark mode

## Description

When using Diaphora's diff viewer with IDA's Dark theme, the diff background colors remain light (`DIFF_COLOR_ADDED`, `DIFF_COLOR_CHANGED`, `DIFF_COLOR_SUBTRACTED`, and `DIFF_COLOR_LINE_NO`), while the foreground color is inherited from the surrounding IDA UI.

This can result in very poor contrast and make the diff contents difficult to read in Dark mode.

This change explicitly sets the foreground color for the diff regions while leaving the existing configurable background colors unchanged.

## Changes

In `diaphora_ida.py`:

* Set `.diff_add`, `.diff_chg`, and `.diff_sub` foreground text to `#000000`.
* Set `.diff_lineno` foreground text to `#888888`.
* No changes to the existing diff background colors.
* No changes to the diff row/template generation.

## Testing

Tested with IDA Dark mode:

* Added lines: readable
* Changed lines: readable
* Removed lines: readable
* Line numbers: readable
* Existing syntax highlighting remains usable

Also tested with IDA Light mode and confirmed that the change does not negatively affect the diff display.

## Visual comparison

### Before — IDA Dark mode

<img width="1917" height="656" alt="diff" src="https://github.com/user-attachments/assets/af26154c-afce-4749-a440-b1b661203603" />


The original diff viewer has insufficient contrast between the inherited
foreground color and the configured diff backgrounds.

### After — IDA Dark mode

<img width="1919" height="663" alt="dark" src="https://github.com/user-attachments/assets/42fa846b-2fbc-4d2a-9722-8ce2ea3e7679" />


The diff regions now use an explicit foreground color, making the contents
readable while preserving the existing diff background colors.

### After — IDA Light mode

<img width="1912" height="657" alt="light" src="https://github.com/user-attachments/assets/ec714ddb-9a47-4afe-9a48-1ff48d9dc5f8" />


Light mode was also tested and remains unaffected.